### PR TITLE
Mpredfearn/mqtt area

### DIFF
--- a/alarm-monitor.py
+++ b/alarm-monitor.py
@@ -52,19 +52,26 @@ class TexecomConnectMqtt(TexecomConnect):
                 HAZoneType = "safety"
             else:
                 HAZoneType = "motion"
-            topicbase = str("homeassistant/binary_sensor/" + str.lower((zone.text).replace(" ", "_")))
+            name = str.lower((zone.text).replace(" ", "_"))
+            topicbase = str("homeassistant/binary_sensor/" + name)
             configtopic = str(topicbase + "/config")
             statetopic = str(topicbase + "/state")
             message = {
-                "name": str.lower(zone.text).replace(" ", "_"),
+                "name": name,
                 "device_class": HAZoneType,
                 "state_topic": statetopic,
-                "payload_on": 1,
-                "payload_off": 0,
-                "unique_id": id(zone)
+                "payload_on": "1",
+                "payload_off": "0",
+                "unique_id": ".".join([self.panelType, name]),
+                "device": {
+                    "name": "Texecom " + self.panelType + " " + str(self.numberOfZones),
+                    "identifiers": "123456789", #TODO panel serial number?
+                    "manufacturer": "Texecom",
+                    "model": self.panelType + " " + str(self.numberOfZones)
                 }
-            # print(json.dumps(message))
-            client.publish(configtopic,json.dumps(message))
+            }
+            # self.log(configtopic + ":" + json.dumps(message))
+            client.publish(configtopic,json.dumps(message), retain=True)
         return zone
 
 def message_handler(payload):

--- a/texecomConnect.py
+++ b/texecomConnect.py
@@ -41,8 +41,8 @@ class User(object):
 
 class Area(object):
     def __init__(self):
-        pass
-
+        self.name = "unknown"
+        self.state = "unknown"
 
 class Zone(object):
     """Information about a zone and it's current state
@@ -667,6 +667,11 @@ class TexecomConnect(object):
             self.log("zone {:d} type {} name '{}'".
                      format(zone.number, self.zone_types[zone.zoneType], zone.text))
         return zone
+
+    def get_area(self, areaNumber):
+        if areaNumber not in self.zone:
+            self.area[areaNumber] = Area(areaNumber)
+        return self.area[areaNumber]
 
     def get_area_details(self, areaNumber):
         details = self.sendcommand(self.CMD_GETAREADETAILS, chr(areaNumber))


### PR DESCRIPTION
Fix Home assistant auto discovery of zones

Add support for "areas" as Home Assistant "alarm_control_panels"

Home Assistant supports "alarm control panels" which are more or mappable to the panel's "areas". Supply the necessary config topic to auto discovery of each area as an MQTT alarm_control_panel. the area changes state, post to the state topic, which will show up home assistant as the alarm_control_panel changing state. Since the panel only supplys us with a single "part armed" status code, map that to the "armed_night" alarm_control_panel state. Since this will vary by use-case, perhaps some configuration file is required to change this.

Home Assistant alarm_control_panels will show "arm", "disarm" buttons in the user interface, but for now these are not functional since this script so far only reports status, and does not support changing the panel's state.