### PR TITLE
Num zones off by1 for get_all_areas

### DIFF
--- a/texecomConnect.py
+++ b/texecomConnect.py
@@ -769,7 +769,7 @@ class TexecomConnect(object):
 
     def get_all_users(self):
         panel_users = {12: 8, 24: 25, 48: 50, 64: 50, 88: 100, 168: 200, 640: 1000}
-        for usernumber in range(1, panel_users[self.numberOfZones]):
+        for usernumber in range(1, panel_users[self.numberOfZones] + 1):
             user = self.get_user(usernumber)
             if user.valid():
                 self.user[usernumber] = user
@@ -779,7 +779,7 @@ class TexecomConnect(object):
 
     def get_all_areas(self):
         panel_areas = {12: 2, 24: 2, 48: 4, 64: 4, 88: 8, 168: 16, 640: 64}
-        for areanumber in range(1, panel_areas[self.numberOfZones]):
+        for areanumber in range(1, panel_areas[self.numberOfZones] + 1):
             area = self.get_area_details(areanumber)
             self.area[areanumber] = area
 

--- a/texecomConnect.py
+++ b/texecomConnect.py
@@ -769,7 +769,7 @@ class TexecomConnect(object):
 
     def get_all_users(self):
         panel_users = {12: 8, 24: 25, 48: 50, 64: 50, 88: 100, 168: 200, 640: 1000}
-        for usernumber in range(1, panel_users[self.numberOfZones] + 1):
+        for usernumber in range(1, panel_users[self.numberOfZones]):
             user = self.get_user(usernumber)
             if user.valid():
                 self.user[usernumber] = user


### PR DESCRIPTION
Hi David.

I'm using an Premire Elite 64, and noticed that there appears to be an end loop off-by-one in  get_all_areas.
It showed itself on my system due to not getting all the areas (I have 4 out of 4 areas in use)

regards
Charly