### PR TITLE
Handle scenarios where the socket.recv doesn't return the expected length of data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 *.pyc
+.vscode/

--- a/alarm-monitor.py
+++ b/alarm-monitor.py
@@ -48,7 +48,7 @@ class TexecomConnectMqtt(TexecomConnect):
     # Overload get_zone_details to publish zone information to MQTT
     def get_zone_details(self, zone_number):
         zone = super(TexecomConnectMqtt, self).get_zone_details(zone_number)
-        if zone.zoneType != self.ZONETYPE_UNUSED:
+        if zone is not None and zone.zoneType != self.ZONETYPE_UNUSED:
             if zone.zoneType == 1:
                 HAZoneType = "door"
             elif zone.zoneType == 8:


### PR DESCRIPTION
When we receive less data than expected, retry and get what's remaining.